### PR TITLE
Feature/ufs wet removal bb2

### DIFF
--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -1062,7 +1062,7 @@ contains
           call MAPL_GetPointer(internal, NAME=short_name, ptr=int_ptr, __RC__)
           call WetRemovalUFS  (self%km, self%klid, n, self%cdt, GCsuffix, &
                                KIN, MAPL_GRAV, self%radius(n), rainout_eff, self%washout_tuning, & 
-                               int_ptr, ple, t, airdens, pfl_lsan, pfi_lsan, WT, __RC__)
+                               self%wet_radius_thr, int_ptr, ple, t, airdens, pfl_lsan, pfi_lsan, WT, __RC__)
        end do
     case default
        _ASSERT_RC(.false.,'Unsupported wet removal scheme: '//trim(self%wet_removal_scheme),ESMF_RC_NOT_IMPL)

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -1054,8 +1054,9 @@ contains
 !      Both hydrophobic and hydrophilic modes can be removed
        do n = 1, self%nbins
           rainout_eff = 0.0
-          rainout_eff(1)   = self%fwet(n) ! remove with ice
-          rainout_eff(n+1) = self%fwet(n) ! remove with snow (phobic) or rain (philic)
+          rainout_eff(1)   = self%fwet_ice(n)  ! remove with ice
+          rainout_eff(2)   = self%fwet_snow(n) ! remove with snow
+          rainout_eff(3)   = self%fwet_rain(n) ! remove with rain
 
           call MAPL_VarSpecGet(InternalSpec(n), SHORT_NAME=short_name, __RC__)
           call MAPL_GetPointer(internal, NAME=short_name, ptr=int_ptr, __RC__)

--- a/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/CA2G_GridComp/CA2G_GridCompMod.F90
@@ -1061,8 +1061,8 @@ contains
           call MAPL_VarSpecGet(InternalSpec(n), SHORT_NAME=short_name, __RC__)
           call MAPL_GetPointer(internal, NAME=short_name, ptr=int_ptr, __RC__)
           call WetRemovalUFS  (self%km, self%klid, n, self%cdt, GCsuffix, &
-                               KIN, MAPL_GRAV, self%radius(n), rainout_eff, int_ptr, ple, t, airdens, &
-                               pfl_lsan, pfi_lsan, WT, __RC__)
+                               KIN, MAPL_GRAV, self%radius(n), rainout_eff, self%washout_tuning, & 
+                               int_ptr, ple, t, airdens, pfl_lsan, pfi_lsan, WT, __RC__)
        end do
     case default
        _ASSERT_RC(.false.,'Unsupported wet removal scheme: '//trim(self%wet_removal_scheme),ESMF_RC_NOT_IMPL)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -184,12 +184,12 @@ contains
 !   --------------------------------
     select case (self%emission_scheme)
     case ('fengsha')
-       call ESMF_ConfigGetAttribute (cfg, self%alpha,      label='alpha:', default=0.1, __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%gamma,      label='gamma:', default=1.0,  __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', default=1.0, __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%f_sdl,      label='soil_drylimit_factor:',default=1.0, __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', default=2.0e-4, __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', default=1, __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%alpha,      label='alpha:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%gamma,      label='gamma:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%f_sdl,      label='soil_drylimit_factor:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
        
        write(msg,'(5(2x,g20.8))') self%alpha
        call ESMF_LogWrite("FENGSHA: config: alpha: "//msg)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -163,6 +163,8 @@ contains
     call ESMF_ConfigGetAttribute (cfg, self%rlow,       label='radius_lower:', __RC__)
     call ESMF_ConfigGetAttribute (cfg, self%rup,        label='radius_upper:', __RC__)
 
+    ! Choose Emission Scheme
+    !-----------------------
     call ESMF_ConfigGetAttribute (cfg, emission_scheme, label='emission_scheme:', default='ginoux', __RC__)
     self%emission_scheme = ESMF_UtilStringLowerCase(trim(emission_scheme), __RC__)
 
@@ -172,6 +174,7 @@ contains
        write (*,*) trim(Iam)//": Dust emission scheme is "//trim(self%emission_scheme)
     end if
 
+    ! Point Sources 
     call ESMF_ConfigGetAttribute (cfg, self%point_emissions_srcfilen, &
                                   label='point_emissions_srcfilen:', default='/dev/null', __RC__)
     if ( (index(self%point_emissions_srcfilen,'/dev/null')>0) ) then
@@ -184,12 +187,12 @@ contains
 !   --------------------------------
     select case (self%emission_scheme)
     case ('fengsha')
-       call ESMF_ConfigGetAttribute (cfg, self%alpha,      label='alpha:', __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%gamma,      label='gamma:', __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%f_sdl,      label='soil_drylimit_factor:', __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%alpha,    label='alpha:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%gamma,    label='gamma:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%f_swc,    label='soil_moisture_factor:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%f_sdl,    label='soil_drylimit_factor:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%kvhmax,   label='vertical_to_horizontal_flux_ratio_limit:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%drag_opt, label='drag_partition_option:', __RC__)
        
        if (MAPL_AM_I_ROOT()) then
          write (*,*) "FENGSHA: config: alpha: " , self%alpha

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -995,8 +995,8 @@ contains
         rainout_eff(2)   = self%fwet_snow(n) ! remove with snow
         rainout_eff(3)   = self%fwet_rain(n) ! remove with rain
         call WetRemovalUFS     (self%km, self%klid, n, self%cdt, 'dust', KIN, MAPL_GRAV, &
-                                 self%radius(n), rainout_eff, self%washout_tuning, DU(:,:,:,n), ple, t, airdens, &
-                                 pfl_lsan, pfi_lsan, DUWT, __RC__)
+                                 self%radius(n), rainout_eff, self%washout_tuning, self%wet_radius_thr, &
+                                 DU(:,:,:,n), ple, t, airdens, pfl_lsan, pfi_lsan, DUWT, __RC__)
       end do
    case default
       _ASSERT_RC(.false.,'Unsupported wet removal scheme: '//trim(self%wet_removal_scheme),ESMF_RC_NOT_IMPL)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -188,7 +188,7 @@ contains
        call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%f_sdl,      label='soil_drylimit_factor:',default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', default=2.0e-04, __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', default=1.0, __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
     case ('k14')
        call ESMF_ConfigGetAttribute (cfg, self%clayFlag,   label='clayFlag:', __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', __RC__)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -188,7 +188,7 @@ contains
        call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%f_sdl,      label='soil_drylimit_factor:',default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', default=2.0e-4, __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', default=1, __RC__)
     case ('k14')
        call ESMF_ConfigGetAttribute (cfg, self%clayFlag,   label='clayFlag:', __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', __RC__)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -991,9 +991,10 @@ contains
    case ('ufs')
       rainout_eff = 0.0
       do n = 1, self%nbins
-         rainout_eff(1) = self%fwet(n)  ! remove with ice
-         rainout_eff(2) = self%fwet(n)  ! remove with snow
-         call WetRemovalUFS     (self%km, self%klid, n, self%cdt, 'dust', KIN, MAPL_GRAV, &
+        rainout_eff(1)   = self%fwet_ice(n)  ! remove with ice
+        rainout_eff(2)   = self%fwet_snow(n) ! remove with snow
+        rainout_eff(3)   = self%fwet_rain(n) ! remove with rain
+        call WetRemovalUFS     (self%km, self%klid, n, self%cdt, 'dust', KIN, MAPL_GRAV, &
                                  self%radius(n), rainout_eff, DU(:,:,:,n), ple, t, airdens, &
                                  pfl_lsan, pfi_lsan, DUWT, __RC__)
       end do

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -813,21 +813,10 @@ contains
        if (associated(DU_EROD)) DU_EROD = f_erod_
 
     case ('fengsha')
-    !    allocate(ustar_, mold=U10M,    __STAT__)
-    !    allocate(ustar_t_, mold=U10M,  __STAT__)
-    !    allocate(ustar_ts_, mold=U10M, __STAT__)
-    !    allocate(R_, mold=U10M,        __STAT__)
-    !    allocate(H_w_, mold=U10M,      __STAT__)
-       call DustEmissionFENGSHA (frlake, frsnow, lwi, slc, du_clay, du_sand, du_silt,       &
-                                 du_ssm, du_rdrag, airdens(:,:,self%km), ustar, du_gvf, du_lai, du_uthres,  &
-                                 self%alpha, self%gamma, self%kvhmax, MAPL_GRAV,   &
-                                 self%rhop, self%sdist, self%f_sdl, self%f_swc, self%drag_opt, emissions_surface, __RC__) ! &
-                                 ! ustar_, ustar_t_, ustar_ts_, R_, H_w_, __RC__)
-    !    if (associated(DU_UST)) DU_UST = ustar_
-    !    if (associated(DU_UST_T)) DU_UST_T = ustar_t_
-    !    if (associated(DU_UST_T)) DU_UST_T = ustar_ts_
-    !    if (associated(DU_DPC)) DU_DPC = R_
-    !    if (associated(DU_SMC)) DU_SMC = H_w_
+        call DustEmissionFENGSHA (frlake, frsnow, lwi, slc, du_clay, du_sand, du_silt,       &
+                du_ssm, du_rdrag, airdens(:,:,self%km), ustar, du_gvf, du_lai, du_uthres,  &
+                self%alpha, self%gamma, self%kvhmax, MAPL_GRAV,   &
+                self%rhop, self%sdist, self%f_sdl, self%f_swc, self%drag_opt, emissions_surface,  __RC__)
 
     case ('ginoux')
 

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -187,7 +187,7 @@ contains
        call ESMF_ConfigGetAttribute (cfg, self%gamma,      label='gamma:', default=1.0,  __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%f_sdl,      label='soil_drylimit_factor:',default=1.0, __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', default=2.0e-04, __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', default=2.0e-4, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
     case ('k14')
        call ESMF_ConfigGetAttribute (cfg, self%clayFlag,   label='clayFlag:', __RC__)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -201,7 +201,7 @@ contains
        call ESMF_LogWrite("FENGSHA: config: soil_drylimit_factor: "//msg)
        write(msg,'(5(2x,g20.8))') self%vertical_to_horizontal_flux_ratio_limit
        call ESMF_LogWrite("FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: "//msg)
-       write(msg,'(5(2x,g20.8))') self%drag_partition_option
+       write(msg,'(5(2x,g20.8))') self%drag_opt
        call ESMF_LogWrite("FENGSHA: config: drag_partition_option: "//msg)
        
     case ('k14')

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -192,12 +192,18 @@ contains
        call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
        
        if (MAPL_AM_I_ROOT()) then
-         write (*,*) trim(Iam)//": FENGSHA: config: alpha: "//self%alpha)
-         write (*,*) trim(Iam)//": FENGSHA: config: gamma: "//self%gamma)
-         write (*,*) trim(Iam)//": FENGSHA: config: soil_moisture_factor: "//self%f_swc)
-         write (*,*) trim(Iam)//": FENGSHA: config: soil_drylimit_factor: "//self%f_sdl)
-         write (*,*) trim(Iam)//": FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: "//self%kvhmax)
-         write (*,*) trim(Iam)//": FENGSHA: config: drag_partition_option: "//self%drag_opt)
+        write(msg,'(5(2x,g20.8))') self%alpha
+         write (*,*) trim(Iam)//": FENGSHA: config: alpha: "//msg 
+         write(msg,'(5(2x,g20.8))') self%gamma
+         write (*,*) trim(Iam)//": FENGSHA: config: gamma: "//msg
+         write(msg,'(5(2x,g20.8))') self%f_swc
+         write (*,*) trim(Iam)//": FENGSHA: config: soil_moisture_factor: "//msg
+         write(msg,'(5(2x,g20.8))') self%f_sdl
+         write (*,*) trim(Iam)//": FENGSHA: config: soil_drylimit_factor: "//msg
+         write(msg,'(5(2x,g20.8))') self%kvhmax
+         write (*,*) trim(Iam)//": FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: "//msg
+         write(msg,'(5(2x,g20.8))') self%drag_opt
+         write (*,*) trim(Iam)//": FENGSHA: config: drag_partition_option: "//msg
        end if
        
     case ('k14')

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -192,12 +192,12 @@ contains
        call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
        
        if (MAPL_AM_I_ROOT()) then
-         write (*,*) "FENGSHA: config: alpha: ", self%alpha
-         write (*,*) "FENGSHA: config: gamma: "self%gamma
-         write (*,*) "FENGSHA: config: soil_moisture_factor: ", self%f_swc
-         write (*,*) "FENGSHA: config: soil_drylimit_factor: ", self%f_sdl
-         write (*,*) "FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: ", self%kvhmax
-         write (*,*) "FENGSHA: config: drag_partition_option: ", self%drag_opt
+         write (*,*) "FENGSHA: config: alpha: " // self%alpha
+         write (*,*) "FENGSHA: config: gamma: " // self%gamma
+         write (*,*) "FENGSHA: config: soil_moisture_factor: " // self%f_swc
+         write (*,*) "FENGSHA: config: soil_drylimit_factor: " // self%f_sdl
+         write (*,*) "FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: " //  self%kvhmax
+         write (*,*) "FENGSHA: config: drag_partition_option: " // self%drag_opt
        end if
        
     case ('k14')

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -802,21 +802,21 @@ contains
        if (associated(DU_EROD)) DU_EROD = f_erod_
 
     case ('fengsha')
-       allocate(ustar_, mold=U10M,    __STAT__)
-       allocate(ustar_t_, mold=U10M,  __STAT__)
-       allocate(ustar_ts_, mold=U10M, __STAT__)
-       allocate(R_, mold=U10M,        __STAT__)
-       allocate(H_w_, mold=U10M,      __STAT__)
+    !    allocate(ustar_, mold=U10M,    __STAT__)
+    !    allocate(ustar_t_, mold=U10M,  __STAT__)
+    !    allocate(ustar_ts_, mold=U10M, __STAT__)
+    !    allocate(R_, mold=U10M,        __STAT__)
+    !    allocate(H_w_, mold=U10M,      __STAT__)
        call DustEmissionFENGSHA (frlake, frsnow, lwi, slc, du_clay, du_sand, du_silt,       &
                                  du_ssm, du_rdrag, airdens(:,:,self%km), ustar, du_gvf, du_lai, du_uthres,  &
                                  self%alpha, self%gamma, self%kvhmax, MAPL_GRAV,   &
-                                 self%rhop, self%sdist, self%f_sdl, self%f_swc, self%drag_opt, emissions_surface, &
-                                 ustar_, ustar_t_, ustar_ts_, R_, H_w_, __RC__)
-       if (associated(DU_UST)) DU_UST = ustar_
-       if (associated(DU_UST_T)) DU_UST_T = ustar_t_
-       if (associated(DU_UST_T)) DU_UST_T = ustar_ts_
-       if (associated(DU_DPC)) DU_DPC = R_
-       if (associated(DU_SMC)) DU_SMC = H_w_
+                                 self%rhop, self%sdist, self%f_sdl, self%f_swc, self%drag_opt, emissions_surface, __RC__) ! &
+                                 ! ustar_, ustar_t_, ustar_ts_, R_, H_w_, __RC__)
+    !    if (associated(DU_UST)) DU_UST = ustar_
+    !    if (associated(DU_UST_T)) DU_UST_T = ustar_t_
+    !    if (associated(DU_UST_T)) DU_UST_T = ustar_ts_
+    !    if (associated(DU_DPC)) DU_DPC = R_
+    !    if (associated(DU_SMC)) DU_SMC = H_w_
 
     case ('ginoux')
 

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -195,11 +195,11 @@ contains
        call ESMF_LogWrite("FENGSHA: config: alpha: "//msg)
        write(msg,'(5(2x,g20.8))') self%gamma
        call ESMF_LogWrite("FENGSHA: config: gamma: "//msg)
-       write(msg,'(5(2x,g20.8))') self%soil_moisture_factor
+       write(msg,'(5(2x,g20.8))') self%f_swc
        call ESMF_LogWrite("FENGSHA: config: soil_moisture_factor: "//msg)
-       write(msg,'(5(2x,g20.8))') self%soil_drylimit_factor
+       write(msg,'(5(2x,g20.8))') self%f_sdl
        call ESMF_LogWrite("FENGSHA: config: soil_drylimit_factor: "//msg)
-       write(msg,'(5(2x,g20.8))') self%vertical_to_horizontal_flux_ratio_limit
+       write(msg,'(5(2x,g20.8))') self%kvhmax
        call ESMF_LogWrite("FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: "//msg)
        write(msg,'(5(2x,g20.8))') self%drag_opt
        call ESMF_LogWrite("FENGSHA: config: drag_partition_option: "//msg)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -995,7 +995,7 @@ contains
         rainout_eff(2)   = self%fwet_snow(n) ! remove with snow
         rainout_eff(3)   = self%fwet_rain(n) ! remove with rain
         call WetRemovalUFS     (self%km, self%klid, n, self%cdt, 'dust', KIN, MAPL_GRAV, &
-                                 self%radius(n), rainout_eff, DU(:,:,:,n), ple, t, airdens, &
+                                 self%radius(n), rainout_eff, self%washout_tuning, DU(:,:,:,n), ple, t, airdens, &
                                  pfl_lsan, pfi_lsan, DUWT, __RC__)
       end do
    case default

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -191,18 +191,14 @@ contains
        call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
        
-       write(msg,'(5(2x,g20.8))') self%alpha
-       call ESMF_LogWrite("FENGSHA: config: alpha: "//msg)
-       write(msg,'(5(2x,g20.8))') self%gamma
-       call ESMF_LogWrite("FENGSHA: config: gamma: "//msg)
-       write(msg,'(5(2x,g20.8))') self%f_swc
-       call ESMF_LogWrite("FENGSHA: config: soil_moisture_factor: "//msg)
-       write(msg,'(5(2x,g20.8))') self%f_sdl
-       call ESMF_LogWrite("FENGSHA: config: soil_drylimit_factor: "//msg)
-       write(msg,'(5(2x,g20.8))') self%kvhmax
-       call ESMF_LogWrite("FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: "//msg)
-       write(msg,'(5(2x,g20.8))') self%drag_opt
-       call ESMF_LogWrite("FENGSHA: config: drag_partition_option: "//msg)
+       if (MAPL_AM_I_ROOT()) then
+         write (*,*) trim(Iam)//": FENGSHA: config: alpha: "//self%alpha)
+         write (*,*) trim(Iam)//": FENGSHA: config: gamma: "//self%gamma)
+         write (*,*) trim(Iam)//": FENGSHA: config: soil_moisture_factor: "//self%f_swc)
+         write (*,*) trim(Iam)//": FENGSHA: config: soil_drylimit_factor: "//self%f_sdl)
+         write (*,*) trim(Iam)//": FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: "//self%kvhmax)
+         write (*,*) trim(Iam)//": FENGSHA: config: drag_partition_option: "//self%drag_opt)
+       end if
        
     case ('k14')
        call ESMF_ConfigGetAttribute (cfg, self%clayFlag,   label='clayFlag:', __RC__)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -121,6 +121,7 @@ contains
     logical                            :: data_driven = .true.
     logical                            :: file_exists
     integer :: num_threads
+    character(len=255) :: msg
 
     __Iam__('SetServices')
 
@@ -189,6 +190,20 @@ contains
        call ESMF_ConfigGetAttribute (cfg, self%f_sdl,      label='soil_drylimit_factor:',default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%kvhmax,     label='vertical_to_horizontal_flux_ratio_limit:', default=2.0e-4, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', default=1, __RC__)
+       
+       write(msg,'(5(2x,g20.8))') self%alpha
+       call ESMF_LogWrite("FENGSHA: config: alpha: "//msg)
+       write(msg,'(5(2x,g20.8))') self%gamma
+       call ESMF_LogWrite("FENGSHA: config: gamma: "//msg)
+       write(msg,'(5(2x,g20.8))') self%soil_moisture_factor
+       call ESMF_LogWrite("FENGSHA: config: soil_moisture_factor: "//msg)
+       write(msg,'(5(2x,g20.8))') self%soil_drylimit_factor
+       call ESMF_LogWrite("FENGSHA: config: soil_drylimit_factor: "//msg)
+       write(msg,'(5(2x,g20.8))') self%vertical_to_horizontal_flux_ratio_limit
+       call ESMF_LogWrite("FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: "//msg)
+       write(msg,'(5(2x,g20.8))') self%drag_partition_option
+       call ESMF_LogWrite("FENGSHA: config: drag_partition_option: "//msg)
+       
     case ('k14')
        call ESMF_ConfigGetAttribute (cfg, self%clayFlag,   label='clayFlag:', __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%f_swc,      label='soil_moisture_factor:', __RC__)

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -192,12 +192,12 @@ contains
        call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
        
        if (MAPL_AM_I_ROOT()) then
-         write (*,*) "FENGSHA: config: alpha: " // self%alpha
-         write (*,*) "FENGSHA: config: gamma: " // self%gamma
-         write (*,*) "FENGSHA: config: soil_moisture_factor: " // self%f_swc
-         write (*,*) "FENGSHA: config: soil_drylimit_factor: " // self%f_sdl
-         write (*,*) "FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: " //  self%kvhmax
-         write (*,*) "FENGSHA: config: drag_partition_option: " // self%drag_opt
+         write (*,*) "FENGSHA: config: alpha: " , self%alpha
+         write (*,*) "FENGSHA: config: gamma: " , self%gamma
+         write (*,*) "FENGSHA: config: soil_moisture_factor: " , self%f_swc
+         write (*,*) "FENGSHA: config: soil_drylimit_factor: " , self%f_sdl
+         write (*,*) "FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: " ,  self%kvhmax
+         write (*,*) "FENGSHA: config: drag_partition_option: " , self%drag_opt
        end if
        
     case ('k14')

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_GridCompMod.F90
@@ -192,18 +192,12 @@ contains
        call ESMF_ConfigGetAttribute (cfg, self%drag_opt,   label='drag_partition_option:', __RC__)
        
        if (MAPL_AM_I_ROOT()) then
-        write(msg,'(5(2x,g20.8))') self%alpha
-         write (*,*) trim(Iam)//": FENGSHA: config: alpha: "//msg 
-         write(msg,'(5(2x,g20.8))') self%gamma
-         write (*,*) trim(Iam)//": FENGSHA: config: gamma: "//msg
-         write(msg,'(5(2x,g20.8))') self%f_swc
-         write (*,*) trim(Iam)//": FENGSHA: config: soil_moisture_factor: "//msg
-         write(msg,'(5(2x,g20.8))') self%f_sdl
-         write (*,*) trim(Iam)//": FENGSHA: config: soil_drylimit_factor: "//msg
-         write(msg,'(5(2x,g20.8))') self%kvhmax
-         write (*,*) trim(Iam)//": FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: "//msg
-         write(msg,'(5(2x,g20.8))') self%drag_opt
-         write (*,*) trim(Iam)//": FENGSHA: config: drag_partition_option: "//msg
+         write (*,*) "FENGSHA: config: alpha: ", self%alpha
+         write (*,*) "FENGSHA: config: gamma: "self%gamma
+         write (*,*) "FENGSHA: config: soil_moisture_factor: ", self%f_swc
+         write (*,*) "FENGSHA: config: soil_drylimit_factor: ", self%f_sdl
+         write (*,*) "FENGSHA: config: vertical_to_horizontal_flux_ratio_limit: ", self%kvhmax
+         write (*,*) "FENGSHA: config: drag_partition_option: ", self%drag_opt
        end if
        
     case ('k14')

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
@@ -9,7 +9,8 @@ category: IMPORT
 #-------------------------------------------------------------------------------------------------------
  DU_SRC     | 1        | xy   | N    | SKIP    | scheme == 'ginoux' .OR. scheme == 'k14'  | erod - dust emissions
  DU_Z0      | 1        | xy   | N    | SKIP    | scheme == 'k14'                          | aerodynamic_surface_roughness_for_aeolian_processes
- DU_GVF     | 1        | xy   | N    | OPT     | scheme == 'k14'                          | GVF
+ DU_GVF     | 1        | xy   | N    | OPT     | scheme == 'k14' .OR. scheme == 'FENGSHA' | GVF
+ DU_LAI     | 1        | xy   | N    | OPT     | scheme == 'fengsha'                      | LAI
  DU_SAND    | 1        | xy   | N    | SKIP    | scheme == 'fengsha' .OR. scheme == 'k14' | volume_fraction_of_sand_in_soil
  DU_SILT    | 1        | xy   | N    | SKIP    | scheme == 'fengsha' .OR. scheme == 'k14' | volume_fraction_of_silt_in_soil
  DU_CLAY    | 1        | xy   | N    | SKIP    | scheme == 'fengsha' .OR. scheme == 'k14' | volume_fraction_of_clay_in_soil

--- a/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
+++ b/ESMF/GOCART2G_GridComp/DU2G_GridComp/DU2G_StateSpecs.rc
@@ -9,7 +9,7 @@ category: IMPORT
 #-------------------------------------------------------------------------------------------------------
  DU_SRC     | 1        | xy   | N    | SKIP    | scheme == 'ginoux' .OR. scheme == 'k14'  | erod - dust emissions
  DU_Z0      | 1        | xy   | N    | SKIP    | scheme == 'k14'                          | aerodynamic_surface_roughness_for_aeolian_processes
- DU_GVF     | 1        | xy   | N    | OPT     | scheme == 'k14' .OR. scheme == 'FENGSHA' | GVF
+ DU_GVF     | 1        | xy   | N    | OPT     | scheme == 'fengsha' .OR. scheme == 'k14' | GVF
  DU_LAI     | 1        | xy   | N    | OPT     | scheme == 'fengsha'                      | LAI
  DU_SAND    | 1        | xy   | N    | SKIP    | scheme == 'fengsha' .OR. scheme == 'k14' | volume_fraction_of_sand_in_soil
  DU_SILT    | 1        | xy   | N    | SKIP    | scheme == 'fengsha' .OR. scheme == 'k14' | volume_fraction_of_silt_in_soil

--- a/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
+++ b/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
@@ -22,6 +22,7 @@ module GA_EnvironmentMod
        real, allocatable      :: fwet_ice(:)    ! large scale wet removal scaling factor for ice
        real, allocatable      :: fwet_snow(:)   ! large scale wet removal scaling factor for snow 
        real, allocatable      :: fwet_rain(:)   ! large scale wet removal scaling factor for rain
+       real                   :: washout_tuning ! tuning factor for washout process (1 by default)
        integer                :: rhFlag
        integer                :: nbins
        integer                :: km             ! vertical grid dimension
@@ -79,6 +80,7 @@ module GA_EnvironmentMod
        call ESMF_ConfigGetAttribute (cfg, self%fwet_ice,   label='fwet_ice:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%fwet_snow,  label='fwet_snow:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%fwet_rain,  label='fwet_rain:', default=1.0, __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%washout_tuning,  label='washout_tuning:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, wet_removal_scheme, label='wet_removal_scheme:', default='gocart', __RC__)
        self%wet_removal_scheme = ESMF_UtilStringLowerCase(trim(wet_removal_scheme), __RC__)
 

--- a/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
+++ b/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
@@ -81,7 +81,7 @@ module GA_EnvironmentMod
        call ESMF_ConfigGetAttribute (cfg, self%fwet_ice,   label='fwet_ice:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%fwet_snow,  label='fwet_snow:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%fwet_rain,  label='fwet_rain:', default=1.0, __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%wet_radius_thr,  label='wet_radius_thr:', default=0.3, __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%wet_radius_thr,  label='wet_radius_thr:', default=0.05, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%washout_tuning,  label='washout_tuning:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, wet_removal_scheme, label='wet_removal_scheme:', default='gocart', __RC__)
        self%wet_removal_scheme = ESMF_UtilStringLowerCase(trim(wet_removal_scheme), __RC__)

--- a/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
+++ b/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
@@ -81,7 +81,7 @@ module GA_EnvironmentMod
        call ESMF_ConfigGetAttribute (cfg, self%fwet_ice,   label='fwet_ice:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%fwet_snow,  label='fwet_snow:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%fwet_rain,  label='fwet_rain:', default=1.0, __RC__)
-       call ESMF_ConfigGetAttribute (cfg, self%wet_radius_thr,  label='fwet_rain:', default=0.5, __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%wet_radius_thr,  label='wet_radius_thr:', default=0.3, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%washout_tuning,  label='washout_tuning:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, wet_removal_scheme, label='wet_removal_scheme:', default='gocart', __RC__)
        self%wet_removal_scheme = ESMF_UtilStringLowerCase(trim(wet_removal_scheme), __RC__)

--- a/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
+++ b/ESMF/GOCART2G_GridComp/GA_Environment/GA_EnvironmentMod.F90
@@ -23,6 +23,7 @@ module GA_EnvironmentMod
        real, allocatable      :: fwet_snow(:)   ! large scale wet removal scaling factor for snow 
        real, allocatable      :: fwet_rain(:)   ! large scale wet removal scaling factor for rain
        real                   :: washout_tuning ! tuning factor for washout process (1 by default)
+       real                   :: wet_radius_thr ! wet radius threshold [um]
        integer                :: rhFlag
        integer                :: nbins
        integer                :: km             ! vertical grid dimension
@@ -80,6 +81,7 @@ module GA_EnvironmentMod
        call ESMF_ConfigGetAttribute (cfg, self%fwet_ice,   label='fwet_ice:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%fwet_snow,  label='fwet_snow:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%fwet_rain,  label='fwet_rain:', default=1.0, __RC__)
+       call ESMF_ConfigGetAttribute (cfg, self%wet_radius_thr,  label='fwet_rain:', default=0.5, __RC__)
        call ESMF_ConfigGetAttribute (cfg, self%washout_tuning,  label='washout_tuning:', default=1.0, __RC__)
        call ESMF_ConfigGetAttribute (cfg, wet_removal_scheme, label='wet_removal_scheme:', default='gocart', __RC__)
        self%wet_removal_scheme = ESMF_UtilStringLowerCase(trim(wet_removal_scheme), __RC__)

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -832,8 +832,8 @@ contains
           rainout_eff(2)   = self%fwet_snow(n) ! remove with snow
           rainout_eff(3)   = self%fwet_rain(n) ! remove with rain
           call WetRemovalUFS(self%km, self%klid, n, self%cdt, 'sea_salt', KIN, MAPL_GRAV, &
-                             self%radius(n), rainout_eff, self%washout_tuning, SS(:,:,:,n), ple, t, airdens, &
-                             pfl_lsan, pfi_lsan, SSWT, __RC__)
+                             self%radius(n), rainout_eff, self%washout_tuning, self%wet_radius_thr, & 
+                             SS(:,:,:,n), ple, t, airdens, pfl_lsan, pfi_lsan, SSWT, __RC__)
        end do
     case default
        _ASSERT_RC(.false.,'Unsupported wet removal scheme: '//trim(self%wet_removal_scheme),ESMF_RC_NOT_IMPL)

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -828,8 +828,9 @@ contains
     case ('ufs')
        rainout_eff = 0.0
        do n = 1, self%nbins
-          rainout_eff(1) = self%fwet(n) ! remove with ice
-          rainout_eff(3) = self%fwet(n) ! remove with rain
+          rainout_eff(1)   = self%fwet_ice(n)  ! remove with ice
+          rainout_eff(2)   = self%fwet_snow(n) ! remove with snow
+          rainout_eff(3)   = self%fwet_rain(n) ! remove with rain
           call WetRemovalUFS     (self%km, self%klid, n, self%cdt, 'sea_salt', KIN, MAPL_GRAV, &
                                   self%radius(n), rainout_eff, SS(:,:,:,n), ple, t, airdens, &
                                   pfl_lsan, pfi_lsan, SSWT, __RC__)

--- a/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
+++ b/ESMF/GOCART2G_GridComp/SS2G_GridComp/SS2G_GridCompMod.F90
@@ -831,9 +831,9 @@ contains
           rainout_eff(1)   = self%fwet_ice(n)  ! remove with ice
           rainout_eff(2)   = self%fwet_snow(n) ! remove with snow
           rainout_eff(3)   = self%fwet_rain(n) ! remove with rain
-          call WetRemovalUFS     (self%km, self%klid, n, self%cdt, 'sea_salt', KIN, MAPL_GRAV, &
-                                  self%radius(n), rainout_eff, SS(:,:,:,n), ple, t, airdens, &
-                                  pfl_lsan, pfi_lsan, SSWT, __RC__)
+          call WetRemovalUFS(self%km, self%klid, n, self%cdt, 'sea_salt', KIN, MAPL_GRAV, &
+                             self%radius(n), rainout_eff, self%washout_tuning, SS(:,:,:,n), ple, t, airdens, &
+                             pfl_lsan, pfi_lsan, SSWT, __RC__)
        end do
     case default
        _ASSERT_RC(.false.,'Unsupported wet removal scheme: '//trim(self%wet_removal_scheme),ESMF_RC_NOT_IMPL)

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3229,8 +3229,8 @@ CONTAINS
      integer  :: i, j, k, km1, ktop, kbot
      real     :: delp, dqls, dqis, f, ftop, f_prime, f_rainout, f_washout, k_rain, dt
      real     :: totloss, lossfrac, wetloss, qdwn, pres
-     real     :: alpha, gain, washed, delz_cm
-     real, dimension(:), allocatable :: qq, pdwn, dpog, conc, dconc, delz, c_h2o, cldice, cldliq
+     real     :: alpha, gain, washed
+     real, dimension(:), allocatable :: qq, pdwn, dpog, conc, dconc, delz, c_h2o, cldice, cldliq, delz_cm
 
      type spc_t
         real     :: retfac

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3342,9 +3342,6 @@ CONTAINS
            k_rain = k_min + qq(k) / cwc
            f = qq(k) / ( k_rain * cwc )
 
-           k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
-           f = qq_kgm3s(k) * cdt / (1.5e-3 * (1.0e-4  + qq_kgm3s(k) / 1.5e-3) * cdt)
-
            call rainout( kin, rainout_eff, f, k_rain, dt, tmpu(i,j,k), delz(k), &
                          pdwn(k), c_h2o(k), cldice(k), cldliq(k), spc, lossfrac )
 
@@ -3365,11 +3362,8 @@ CONTAINS
            f_prime = zero
            ! -- if precipitation is forming in the grid cell
            if (qq(k) > qq_thr) then
-            !  k_rain = k_min + qq(k) / cwc
-            !  f_prime = qq(k) / ( k_rain * cwc )
-
-             k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
-             f_prime = qq_kgm3s(k) * cdt / (1.5e-3 * (1.0e-4  + qq_kgm3s(k) / 1.5e-3) * cdt)
+             k_rain = k_min + qq(k) / cwc
+             f_prime = qq(k) / ( k_rain * cwc )
            end if
 
            ! -- account for precipitation flux

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3467,7 +3467,7 @@ CONTAINS
            if ( f > zero ) then
              qdwn = pdwn(km1)
              call washout( kin, radius, f, tmpu(i,j,k), qdwn, delz_cm(k), & 
-                           dt, spc, WashoutTune, lossfrac )
+                           dt, spc, wtune, lossfrac )
 
              ! -- f is included in lossfrac for aerosols and HNO3
              if ( kin ) then

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -600,27 +600,25 @@ CONTAINS
          !  Compute threshold wind friction velocity using drag partition
          !  -------------------------------------------------------------
          if (drag_opt == 1) then
-            Reff(i,j) = rdrag(i,j)
+            R = rdrag(i,j)
          else if (drag_opt == 2) then
-            Reff(i,j) = DarmenovaDragPartition(rdrag(i,j), vegfrac(i,j), 0.33)
+            R = DarmenovaDragPartition(rdrag(i,j), vegfrac(i,j), 0.33)
          else if (drag_opt == 3) then
-            Reff(i,j) = LeungDragPartition(rdrag(i,j), lai(i,j), vegfrac(i,j), 0.33)
+            R = LeungDragPartition(rdrag(i,j), lai(i,j), vegfrac(i,j), 0.33)
          end if
          
-         rustar = Reff(i,j) * ustar(i,j)
-         u(i,j) = ustar(i,j) / Reff(i,j)
+         rustar = R * ustar(i,j)
          
          ! Fecan moisture correction
          ! -------------------------
          smois = slc(i,j) * moist_correct
-         H_w(i,j) = moistureCorrectionFecan(smois, sand(i,j), clay(i,j), drylimit_factor)
+         h = moistureCorrectionFecan(smois, sand(i,j), clay(i,j), drylimit_factor)
 
          ! Adjust threshold
          ! ----------------
-         u_t(i,j) = uthrs(i,j) * H_w(i,j)
-         u_ts(i,j) = uthrs(i,j) * H_w(i,j) / Reff(i,j)
+         u_thresh = uthrs(i,j) * h
          
-         u_sum = rustar + u_t(i,j)
+         u_sum = rustar + u_thresh
          
          ! Compute Horizontal Saltation Flux according to Eq (9) in Webb et al. (2020)
          ! ---------------------------------------------------------------------------

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -606,20 +606,20 @@ CONTAINS
          else if (drag_opt == 3) then
             R = LeungDragPartition(rdrag(i,j), lai(i,j), vegfrac(i,j), 0.33)
          end if
-         if (R /= R) then 
-            print*, 'ERROR1:', R, lai(i,j), vegfrac(i,j), rdrag(i,j)
-            stop
-         endif
+         ! if (R /= R) then 
+         !    print*, 'ERROR1:', R, lai(i,j), vegfrac(i,j), rdrag(i,j)
+         !    stop
+         ! endif
          
-         if (R > HUGE(R)) then 
-            print*, 'ERROR2:',R, lai(i,j), vegfrac(i,j), rdrag(i,j)
-            stop
-         endif
+         ! if (R > HUGE(R)) then 
+         !    print*, 'ERROR2:',R, lai(i,j), vegfrac(i,j), rdrag(i,j)
+         !    stop
+         ! endif
 
-         if (( R <= 0.) .or. (R > 1)) then
-            print*, 'Error3:', R, lai(i,j), vegfrac(i,j), rdrag(i,j)
-            stop
-         endif
+         ! if (( R <= 0.) .or. (R > 1)) then
+         !    print*, 'Error3:', R, lai(i,j), vegfrac(i,j), rdrag(i,j)
+         !    stop
+         ! endif
 
          rustar = R * ustar(i,j)
          

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -554,7 +554,7 @@ CONTAINS
 !  Initialize variables 
 !  --------------------
    emissions = 0.
-   Reff = 0.
+   Reff = 1.0e-04
    H_w = 1.0
    u = 0.
    u_t = 0.

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3642,7 +3642,6 @@ CONTAINS
        real, parameter :: radius_fine = 0.01 ! um
        real, parameter :: k_wash = 1.06e-03
        real, parameter :: h2s = 3600.0 ! s-1
-       real, parameter :: 
 
        ! -- begin
 

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3609,7 +3609,7 @@ CONTAINS
        real            :: dth, pph
 
        ! -- local parameters
-       real, parameter :: radius_fine = 0.5 ! um
+       real, parameter :: radius_fine = 0.01 ! um
        real, parameter :: k_wash = 1.06e-03
        real, parameter :: h2s = 3600.0
 

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3459,7 +3459,7 @@ CONTAINS
        end do
      end do
 
-     deallocate(qq, pdwn, conc, dconc, dpog, delz,, delz_cm, c_h2o, cldice, cldliq)
+     deallocate(qq, pdwn, conc, dconc, dpog, delz, delz_cm, c_h2o, cldice, cldliq)
 
    contains
 

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3250,6 +3250,7 @@ CONTAINS
      real     :: alpha      ! ratio of evap. to sublimation
      real     :: gain       ! gain fraction
      real     :: washed     ! concentration of washed out tracer
+     real     :: delz       ! thickness of layer [m]
      real, dimension(:), allocatable :: qq      ! precipatitng water rate [cm3 (h2o) / cm2 (air) / s]
      real, dimension(:), allocatable :: pdwn    ! preciptation rate at top of grid cells [cm3 (h2o) / cm2 (air) / s]
      real, dimension(:), allocatable :: dpog    ! pressure thickness of grid cells divided by gravity [Pa / (m/s^2)]

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -428,7 +428,7 @@ CONTAINS
    
    frac_bare  = MAX(1. - LAI / thresh, 0.)
 
-   if ((LAI <= 0) .or. (LAI >= thres)) then
+   if ((LAI <= 0) .or. (LAI >= thresh)) then
       feff_veg = 0.
    else if (LAI < thresh) then
       K = 2. * ( 1 / (1 - LAI) - 1)

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -617,6 +617,9 @@ CONTAINS
          endif
 
          if (( R <= 0.) .or. (R > 1)) then
+            print*, 'Error3:', R, lai(i,j), vegfrac(i,j), rdrag(i,j)
+            stop
+         endif
 
          rustar = R * ustar(i,j)
          

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3230,7 +3230,7 @@ CONTAINS
      real     :: delp, dqls, dqis, f, ftop, f_prime, f_rainout, f_washout, k_rain, dt
      real     :: totloss, lossfrac, wetloss, qdwn, pres
      real     :: alpha, gain, washed
-     real, dimension(:), allocatable :: qq, pdwn, dpog, conc, dconc, delz, c_h2o, cldice, cldliq, qq_kgm3s
+     real, dimension(:), allocatable :: qq, pdwn, dpog, conc, dconc, delz, c_h2o, cldice, cldliq
 
      type spc_t
         real     :: retfac
@@ -3287,7 +3287,7 @@ CONTAINS
 
      dt = cdt
 
-     allocate(qq(ktop:kbot), qq_kgm3s(ktop:kbot), pdwn(ktop:kbot), conc(ktop:kbot), dconc(ktop:kbot), dpog(ktop:kbot), &
+     allocate(qq(ktop:kbot), pdwn(ktop:kbot), conc(ktop:kbot), dconc(ktop:kbot), dpog(ktop:kbot), &
               delz(ktop:kbot), c_h2o(ktop:kbot), cldice(ktop:kbot), cldliq(ktop:kbot))
 
      do j = jl, ju
@@ -3307,7 +3307,6 @@ CONTAINS
 
            ! -- total precipitation formation (convert from kg/m2/s to cm3/cm3/s)
            qq(k) = ( kg_to_cm3_liq * dqls + kg_to_cm3_ice * dqis ) / delz(k)
-           qq_kgm3s(k) = ( dqls + dqis ) / delz(k)
 
            ! -- precipitation flux from upper level (convert from kg/m2/s to cm3/cm2/s)
            pdwn(k) = kg_to_cm3_liq * pfllsan(i,j,km1) &

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3602,48 +3602,33 @@ CONTAINS
        real            :: dth, pph
 
        ! -- local parameters
-       real, parameter :: radius_fine = 1.0 ! um
+       real, parameter :: radius_fine = 0.5 ! um
        real, parameter :: k_wash = 1.06e-03
        real, parameter :: h2s = 3600.0
-
-       real, dimension(2,2), parameter :: alpha = reshape([ &
-       ! alpha            | size   | precip. type
-       !------------------|--------|-------------
-         26.0 * k_wash, & ! fine   | solid
-                k_wash, & ! fine   | liquid
-         1.57         , & ! coarse | solid
-         0.92           & ! coarse | liquid
-         ], [2,2])
-
-       real, dimension(2,2), parameter :: beta = reshape([ &
-       ! beta     | size   | precip. type
-       !----------|----------------------
-         0.96 , & ! fine   | solid
-         0.61 , & ! fine   | liquid
-         0.96 , & ! coarse | solid
-         0.79   & ! coarse | liquid
-         ], [2,2])
 
        ! -- begin
 
        washfrac_aerosol = zero
 
        if ( f > zero ) then
-         ! -- select aerosol category (coarse, fine)
-         j = 1
-         if ( radius > radius_fine ) j = 2
-
-         ! -- select precipitation type (liquid, solid)
-         i = 2
-         if ( tk < 268. ) i = 1
-
          ! -- convert instant rates (s-1) to hourly rates
          pph = 10. * pdwn * h2s
          dth = dt / h2s
 
-         washfrac_aerosol = f * ( one - exp( -alpha(i,j) * (pph / f) ** beta(i,j) * dth ) )
-
-       end if
+         if ( radius < radius_fine ) then 
+            if ( tk >= 268. ) then
+               washfrac_aerosol = F * ( one  - EXP(-k_wash * (pph / f ) ** 0.61 * dth))
+            else
+               washfrac_aerosol = F * ( one  - EXP(-26. * k_wash * (pph / f ) ** 0.96 * dth))
+            endif 
+         else
+            if ( tk >= 268. ) then
+               washfrac_aerosol = F * ( one  - EXP(-0.92 * (pph / f ) ** 0.79 * dth))
+            else
+               washfrac_aerosol = F * ( one  - EXP(-1.57 / 0.5 * (pph / f ) ** 0.96 * dth))
+            endif
+         endif
+      endif
 
      end function washfrac_aerosol
 

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -438,7 +438,7 @@ CONTAINS
       feff_veg = ( K + f0 * c) / (K + c)
    endif
    
-   if (Lc <= 0.2) then 
+   if ((Lc <= 0.2) .and. (Lc > zero)) then 
       Lc_bare = Lc / frac_bare
       tmpVal = 1 - sigB * mB * Lc_bare
       if (tmpVal > zero) then 
@@ -577,7 +577,7 @@ CONTAINS
        if (drag_opt == 2 ) then ! Darmenova et al, 2009
          if (.not.skip) skip = (vegfrac(i,j) < 0.) .or. (vegfrac(i,j) >= 0.33)
        else if (drag_opt == 3 ) then ! Leung et al, 2023
-         if (.not.skip) skip = (vegfrac(i,j) < 0.) .or. (lai(i,j) >= 0.33)
+         if (.not.skip) skip = (lai(i,j) < 0.) .or. (lai(i,j) >= 0.33)
        end if
 
        if (.not.skip) skip = (ssm(i,j) < ssm_thresh) &
@@ -617,7 +617,7 @@ CONTAINS
          endif
 
          if (( R <= 0.) .or. (R > 1)) then
-            
+
          rustar = R * ustar(i,j)
          
          ! Fecan moisture correction

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3337,14 +3337,13 @@ CONTAINS
          ! -- starts at the top
          k = ktop
          f = zero
-         f = zero
          if (qq(k) > qq_thr) then
            ! -- compute rainout rate
            k_rain = k_min + qq(k) / cwc
            f = qq(k) / ( k_rain * cwc )
 
-         !   k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
-         !   f = qq_kgm3s(k)  / (1.5e-3 * k_rain )
+           k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
+           f = qq_kgm3s(k) * cdt / (1.5e-3 * (1.0e-4  + qq_kgm3s(k) / 1.5e-3) * cdt)
 
            call rainout( kin, rainout_eff, f, k_rain, dt, tmpu(i,j,k), delz(k), &
                          pdwn(k), c_h2o(k), cldice(k), cldliq(k), spc, lossfrac )
@@ -3366,11 +3365,11 @@ CONTAINS
            f_prime = zero
            ! -- if precipitation is forming in the grid cell
            if (qq(k) > qq_thr) then
-             k_rain = k_min + qq(k) / cwc
-             f_prime = qq(k) / ( k_rain * cwc )
+            !  k_rain = k_min + qq(k) / cwc
+            !  f_prime = qq(k) / ( k_rain * cwc )
 
-            !  k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
-            !  f_prime = qq_kgm3s(k)  / (1.5e-3 * k_rain )
+             k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
+             f_prime = qq_kgm3s(k) * cdt / (1.5e-3 * (1.0e-4  + qq_kgm3s(k) / 1.5e-3) * cdt)
            end if
 
            ! -- account for precipitation flux

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3229,7 +3229,7 @@ CONTAINS
      integer  :: i, j, k, km1, ktop, kbot
      real     :: delp, dqls, dqis, f, ftop, f_prime, f_rainout, f_washout, k_rain, dt
      real     :: totloss, lossfrac, wetloss, qdwn, pres
-     real     :: alpha, gain, washed
+     real     :: alpha, gain, washed, dqis_kgm3s, dqls_kgm3s
      real, dimension(:), allocatable :: qq, pdwn, dpog, conc, dconc, delz, c_h2o, cldice, cldliq, delz_cm
 
      type spc_t

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3331,7 +3331,7 @@ CONTAINS
            else
              cldliq(k) = zero
            end if
-           cldice(k) = cwc - cldliq(k)
+           cldice(k) = MAX(cwc - cldliq(k), zero) ! ensure cldice >= 0
          end do
 
          ! -- starts at the top
@@ -3340,11 +3340,11 @@ CONTAINS
          f = zero
          if (qq(k) > qq_thr) then
            ! -- compute rainout rate
-         !   k_rain = k_min + qq(k) / cwc
-         !   f = qq(k) / ( k_rain * cwc )
+           k_rain = k_min + qq(k) / cwc
+           f = qq(k) / ( k_rain * cwc )
 
-           k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
-           f = qq_kgm3s(k)  / (1.5e-3 * k_rain )
+         !   k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
+         !   f = qq_kgm3s(k)  / (1.5e-3 * k_rain )
 
            call rainout( kin, rainout_eff, f, k_rain, dt, tmpu(i,j,k), delz(k), &
                          pdwn(k), c_h2o(k), cldice(k), cldliq(k), spc, lossfrac )
@@ -3366,11 +3366,11 @@ CONTAINS
            f_prime = zero
            ! -- if precipitation is forming in the grid cell
            if (qq(k) > qq_thr) then
-            !  k_rain = k_min + qq(k) / cwc
-            !  f_prime = qq(k) / ( k_rain * cwc )
+             k_rain = k_min + qq(k) / cwc
+             f_prime = qq(k) / ( k_rain * cwc )
 
-             k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
-             f_prime = qq_kgm3s(k)  / (1.5e-3 * k_rain )
+            !  k_rain = 1.0e-4 + qq_kgm3s(k) / 1.5e-3
+            !  f_prime = qq_kgm3s(k)  / (1.5e-3 * k_rain )
            end if
 
            ! -- account for precipitation flux

--- a/Process_Library/GOCART2G_Process.F90
+++ b/Process_Library/GOCART2G_Process.F90
@@ -3288,7 +3288,7 @@ CONTAINS
      dt = cdt
 
      allocate(qq(ktop:kbot), pdwn(ktop:kbot), conc(ktop:kbot), dconc(ktop:kbot), dpog(ktop:kbot), &
-              delz(ktop:kbot), c_h2o(ktop:kbot), cldice(ktop:kbot), cldliq(ktop:kbot), delz_cm(ktop:kbot), __STAT__)
+              delz(ktop:kbot), c_h2o(ktop:kbot), cldice(ktop:kbot), cldliq(ktop:kbot), delz_cm(ktop:kbot))
 
      do j = jl, ju
        do i = il, iu


### PR DESCRIPTION
Multiple changes here 

- Add inputs for fwet snow ice and rain separately adding full control to the user
- made a separate variable for delz and delz_cm(:) where delz (m)  is only used in the qq conversion meters and therefore no longer an array while delz_cm (cm) is created, allocated and then used throughout the `WetRemovalUFS` subroutine
- include an option to "tune" the washout incase future cases are needed 
     * note that this is just a linear scaling in the `EXP( a * washout_tuning * ( pph / f ) ** b * dt ) `
- Simplified the qq calculation to make it more clear (no change) and also no change in results when reimplementing the rainout method I proposed in the previous version (created a very very small difference) 
- rewrote the washfrac_aerosol to make it easier to read 
- added an input option for the fine radius threshold in washfrac_aerosol - made a default of `0.3 microns` (just smaller than the dry radius of carbon species) 
- added some more comments when declaring variables with description and comments (please double check these just incase I made a mistake) 
- merge dust changes into the branch 
     * includes an option for the drag_partition_option for fengsha 1 - default case, 2 - Darmenova + new bare surface Lc 3 - Lueng et al + new bare surface Lc   


you can see the results of this here with the wetdep5 run [Partha's presentation](https://docs.google.com/presentation/d/1zU2vgjfmGAm0UxeXV2B8ZvWj_H3Su_-jLDweVdirKEA/edit#slide=id.g2f6930314f9_1_75) (note that this is still using the default fengsha dust configuration) 

We are performing a sample run for the EP5rX miniset now 